### PR TITLE
Add SteamID to OnlinePlayersMonitor

### DIFF
--- a/TorchMonitor/TorchMonitor.Monitors/OnlinePlayersMonitor.cs
+++ b/TorchMonitor/TorchMonitor.Monitors/OnlinePlayersMonitor.cs
@@ -69,6 +69,7 @@ namespace TorchMonitor.Monitors
                     .Measurement("players_players")
                     .Tag("player_name", playerName)
                     .Tag("faction_tag", factionTag)
+                    .Field("steam_id", steamId)
                     .Field("is_online", 1)
                     .Field("online_time", onlineTime)
                     .Write();


### PR DESCRIPTION
Adds the SteamID as a field to the `OnlinePlayersMonitor` writer.